### PR TITLE
Fixes failing CSVPropertyTableTest

### DIFF
--- a/src/test/java/com/canoo/ant/table/CSVPropertyTableTest.java
+++ b/src/test/java/com/canoo/ant/table/CSVPropertyTableTest.java
@@ -29,20 +29,25 @@ public class CSVPropertyTableTest extends BaseTestCase {
 
     public void testFolder() throws Exception {
         final APropertyTable table = new CSVPropertyTable();
-
         table.setContainer(getPackageResource("csv"));
 
-        final List rawTable = table.getPropertiesList(null, null);
-        Properties props = (Properties) rawTable.get(0);
-        assertEquals(2, rawTable.size());
-        assertEquals("value11", props.getProperty("header1"));
-        assertEquals("value12", props.getProperty("header2"));
-        assertEquals("one", props.getProperty(".file.name"));
+        final List<?> rawTable = table.getPropertiesList(null, null);
 
-        props = (Properties) rawTable.get(1);
-        assertEquals("value21", props.getProperty("header1"));
-        assertEquals("value22", props.getProperty("header2"));
-        assertEquals("two", props.getProperty(".file.name"));
+        // There is no guarantee of order or sorting when listing directory
+        // contents so we have to check each set of properties
+        for (int i = 0; i < rawTable.size(); i++) {
+            Properties props = (Properties) rawTable.get(i);
+            if (props.getProperty(".file.name").equals("one")) {
+                assertEquals(2, rawTable.size());
+                assertEquals("value11", props.getProperty("header1"));
+                assertEquals("value12", props.getProperty("header2"));
+                assertEquals("one", props.getProperty(".file.name"));
+            } else {
+                assertEquals("value21", props.getProperty("header1"));
+                assertEquals("value22", props.getProperty("header2"));
+                assertEquals("two", props.getProperty(".file.name"));
+            }
+        }
     }
 
     public void testFolderWithSpecificTable() throws Exception {


### PR DESCRIPTION
There is no guarantee or reasonable assumption of order of files
returned from File#listFiles(). On my local instance the files are
returned in the reverse of the expected order but after digging through
some cursory documentation, I could not find an indication that the list
of files is sorted.

This patch refactors the test so as not to make an assumption of the
order of tests. This will fix failling tests where the order is not
preserved by File#listFiles().