### PR TITLE
Allows JSON objects as valid JSON

### DIFF
--- a/src/main/java/com/canoo/webtest/steps/verify/VerifyJsonPath.java
+++ b/src/main/java/com/canoo/webtest/steps/verify/VerifyJsonPath.java
@@ -194,7 +194,7 @@ public class VerifyJsonPath extends Step {
     private boolean isValidJSON(final JsonNode results) throws StepFailedException {
         if( results == null) {
             throw new StepFailedException("Null results received");
-        } else if (!results.isArray()) {
+        } else if (!results.isArray() && !results.isObject()) {
             throw new StepFailedException("Response is not well-formed JSON");
         }
         return true;


### PR DESCRIPTION
The VerifyJsonPath's method for determining if the result node is
validJson only checks if the node is an Array type, but will fail if the
node is an Object type. The method's docstring indicates that the
intended behavior should accept both arrays and objects, this patch
updates the method so as to accept objects as well.